### PR TITLE
Branch de tiss

### DIFF
--- a/I/ft_minishell.h
+++ b/I/ft_minishell.h
@@ -6,7 +6,7 @@
 /*   By: mravera <mravera@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/18 17:19:17 by mravera           #+#    #+#             */
-/*   Updated: 2022/12/16 16:05:55 by mravera          ###   ########.fr       */
+/*   Updated: 2022/12/16 18:54:36 by mravera          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,6 +72,7 @@ int		ms_strlen_tab(char **tab);
 
 //ms_utils_ii
 char	*ms_new_pwd(char *old_pwd);
+char	*ms_new_oldpwd(char *old_pwd);
 
 //builtins
 //ms_echo.c
@@ -83,9 +84,11 @@ int		ms_pwd(char **str);
 
 //ms_cd.c
 int		ms_cd(char **str, t_admin *adm);
+int		ms_cd_update_env(t_list *env, char *old);
 
 //ms_env.c
 t_list	*ms_create_list_env(char **envp);
+int		ms_setup_env(t_list *env);
 void	ms_env(t_list *env);
 
 #endif

--- a/src/ms_cd.c
+++ b/src/ms_cd.c
@@ -6,7 +6,7 @@
 /*   By: mravera <mravera@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/07 18:11:14 by mravera           #+#    #+#             */
-/*   Updated: 2022/12/16 17:17:49 by mravera          ###   ########.fr       */
+/*   Updated: 2022/12/16 18:34:13 by mravera          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,25 +15,35 @@
 int	ms_cd(char **str, t_admin *adm)
 {
 	t_list	*env;
+	char	*old;
 
 	env = adm->env;
 	if (!str[0])
 		return (1);
+	old = ms_new_oldpwd(NULL);
 	if (chdir(str[0]) == -1)
 	{
 		perror(NULL);
+		free(old);
 		return (1);
 	}
+	return (ms_cd_update_env(env, old));
+}
+
+int	ms_cd_update_env(t_list *env, char *old)
+{
 	while (env)
 	{
-		if (ft_strncmp((char *)env->content, "PWD=", 4) == 0)
+		if (ft_strncmp((char *)env->content, "OLDPWD", 7) == 0
+			|| ft_strncmp((char *)env->content, "OLDPWD=", 7) == 0)
 		{
-			printf("YIPIKAYE\n");
-			printf("old content = %s\n", env->content);
-			env->content = (void *)ms_new_pwd(env->content);
-			printf("new content = %s\n", env->content);
+			free(env->content);
+			env->content = old;
 		}
+		else if (ft_strncmp((char *)env->content, "PWD", 4) == 0
+			|| ft_strncmp((char *)env->content, "PWD=", 4) == 0)
+			env->content = (void *)ms_new_pwd(env->content);
 		env = env->next;
-	}
+	}	
 	return (0);
 }

--- a/src/ms_env.c
+++ b/src/ms_env.c
@@ -6,7 +6,7 @@
 /*   By: mravera <mravera@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/15 16:04:16 by mravera           #+#    #+#             */
-/*   Updated: 2022/12/16 18:55:41 by mravera          ###   ########.fr       */
+/*   Updated: 2022/12/16 19:04:34 by mravera          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,8 @@ void	ms_env(t_list *env)
 	}
 	while (env)
 	{
-		printf("%s\n", (char *)env->content);
+		if (ft_strchr((char *)env->content, '='))
+			printf("%s\n", (char *)env->content);
 		env = env->next;
 	}
 	return ;

--- a/src/ms_env.c
+++ b/src/ms_env.c
@@ -6,7 +6,7 @@
 /*   By: mravera <mravera@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/15 16:04:16 by mravera           #+#    #+#             */
-/*   Updated: 2022/12/16 17:17:39 by mravera          ###   ########.fr       */
+/*   Updated: 2022/12/16 18:55:41 by mravera          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,22 @@ t_list	*ms_create_list_env(char **envp)
 		ft_lstadd_back(&list_env, new_elem);
 		i++;
 	}
+	ms_setup_env(list_env);
 	return (list_env);
+}
+
+int	ms_setup_env(t_list *env)
+{
+	while (env)
+	{
+		if (ft_strncmp((char *)env->content, "OLDPWD=", 7) == 0)
+		{
+			free(env->content);
+			env->content = ft_strdup("OLDPWD");
+		}
+		env = env->next;
+	}	
+	return (1);
 }
 
 void	ms_env(t_list *env)

--- a/src/ms_utils_ii.c
+++ b/src/ms_utils_ii.c
@@ -6,7 +6,7 @@
 /*   By: mravera <mravera@student.42lausanne.ch>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/16 16:07:34 by mravera           #+#    #+#             */
-/*   Updated: 2022/12/16 16:10:38 by mravera          ###   ########.fr       */
+/*   Updated: 2022/12/16 18:52:50 by mravera          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,22 @@ char	*ms_new_pwd(char *old_pwd)
 	char	*new_pwd;
 
 	buff = getcwd(NULL, 0);
-	free(old_pwd);
+	if (old_pwd != NULL)
+		free(old_pwd);
 	new_pwd = ft_strjoin("PWD=", buff);
+	free(buff);
+	return (new_pwd);
+}
+
+char	*ms_new_oldpwd(char *old_pwd)
+{
+	char	*buff;
+	char	*new_pwd;
+
+	buff = getcwd(NULL, 0);
+	if (old_pwd != NULL)
+		free(old_pwd);
+	new_pwd = ft_strjoin("OLDPWD=", buff);
 	free(buff);
 	return (new_pwd);
 }


### PR DESCRIPTION
OLDPWD devrait se mettre a jour a l'utilisation de la commande cd. OLDPWD est vide a la creation de l'env.
La fonction "env" n'affiche plus les variable qui n'ont pas de '='.